### PR TITLE
Correct policy-based authorization

### DIFF
--- a/Controllers/APIs/AdminSettingsController.cs
+++ b/Controllers/APIs/AdminSettingsController.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace NewJobSurveyAdmin.Controllers
 {
-    [Authorize]
+    [Authorize(Policy = "UserRole")]
     [Route("api/[controller]")]
     [ApiController]
     public class AdminSettingsController : ControllerBase

--- a/Controllers/APIs/EmployeeTimelineEntriesController.cs
+++ b/Controllers/APIs/EmployeeTimelineEntriesController.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace NewJobSurveyAdmin.Controllers
 {
-    [Authorize]
+    [Authorize(Policy = "UserRole")]
     [Route("api/[controller]")]
     [ApiController]
     public class EmployeeTimelineEntriesController : ControllerBase

--- a/Controllers/APIs/EmployeesController.cs
+++ b/Controllers/APIs/EmployeesController.cs
@@ -16,7 +16,7 @@ using System.Threading.Tasks;
 
 namespace NewJobSurveyAdmin.Controllers
 {
-    [Authorize]
+    [Authorize(Policy = "UserRole")]
     [Route("api/[controller]")]
     [ApiController]
     public class EmployeesController : ControllerBase

--- a/Controllers/APIs/PsaApiController.cs
+++ b/Controllers/APIs/PsaApiController.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace NewJobSurveyAdmin.Controllers
 {
-    [Authorize]
+    [Authorize(Policy = "UserRole")]
     [Route("api/[controller]")]
     [ApiController]
     public class PsaApiController : ControllerBase

--- a/Controllers/APIs/TaskLogEntriesController.cs
+++ b/Controllers/APIs/TaskLogEntriesController.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace NewJobSurveyAdmin.Controllers
 {
-    [Authorize]
+    [Authorize(Policy = "UserRole")]
     [Route("api/[controller]")]
     [ApiController]
     public class TaskLogEntriesController : ControllerBase

--- a/Controllers/Services/Authentication/Authentication.cs
+++ b/Controllers/Services/Authentication/Authentication.cs
@@ -37,8 +37,7 @@ namespace NewJobSurveyAdmin.Services
 
         public static void SetAuthorizationOptions(
             AuthorizationOptions options,
-            string roleName,
-            string roleClaimType
+            string roleName
         )
         {
             options.AddPolicy("UserRole", policy =>

--- a/Controllers/Services/Authentication/Authentication.cs
+++ b/Controllers/Services/Authentication/Authentication.cs
@@ -14,32 +14,35 @@ namespace NewJobSurveyAdmin.Services
         }
 
         public static void SetJwtBearerOptions(
-            JwtBearerOptions options, string authority, string audience
+            JwtBearerOptions options,
+            string authority,
+            string audience,
+            string roleClaimType
         )
         {
-            // TODO: Review this section.
             options.Authority = authority;
             options.TokenValidationParameters = new TokenValidationParameters
             {
-                // BC Dev Keycloak
                 ValidAudiences = new string[]
                 {
-                    audience, "account", "realm-management"
+                    audience
                 },
-                RoleClaimType = "role" // Roles in the token for the client.
+                RoleClaimType = roleClaimType
             };
-            options.RequireHttpsMetadata = false; // TODO: Remove?
+            options.RequireHttpsMetadata = true;
             options.SaveToken = true;
 
             options.Validate();
         }
 
         public static void SetAuthorizationOptions(
-            AuthorizationOptions options, string roleName
+            AuthorizationOptions options,
+            string roleName,
+            string roleClaimType
         )
         {
             options.AddPolicy("UserRole", policy =>
-                policy.RequireClaim("role", $"[{roleName}]")
+                policy.RequireRole(roleName)
             );
         }
     }

--- a/Startup.cs
+++ b/Startup.cs
@@ -116,8 +116,7 @@ namespace NewJobSurveyAdmin
                 .AddAuthorization(options =>
                     Authentication.SetAuthorizationOptions(
                         options,
-                        Configuration.GetValue<string>("Authentication:RoleName"),
-                        Configuration.GetValue<string>("Authentication:RoleClaimType")
+                        Configuration.GetValue<string>("Authentication:RoleName")
                     )
                 );
 

--- a/Startup.cs
+++ b/Startup.cs
@@ -106,7 +106,8 @@ namespace NewJobSurveyAdmin
                     Authentication.SetJwtBearerOptions(
                         options,
                         Configuration.GetValue<string>("Authentication:Authority"),
-                        Configuration.GetValue<string>("Authentication:Audience")
+                        Configuration.GetValue<string>("Authentication:Audience"),
+                        Configuration.GetValue<string>("Authentication:RoleClaimType")
                     )
                 );
 
@@ -115,7 +116,8 @@ namespace NewJobSurveyAdmin
                 .AddAuthorization(options =>
                     Authentication.SetAuthorizationOptions(
                         options,
-                        Configuration.GetValue<string>("Authentication:RoleName")
+                        Configuration.GetValue<string>("Authentication:RoleName"),
+                        Configuration.GetValue<string>("Authentication:RoleClaimType")
                     )
                 );
 

--- a/secret/appsettings.secret-template.json
+++ b/secret/appsettings.secret-template.json
@@ -4,14 +4,14 @@
   },
   "Authentication": {
     "Authority": "The URL of the KeyCloak realm, e.g. https://some-keycloak-server/auth/realms/someRealmID",
-    "RoleName": "The role name for an New Job Survey Admin user, e.g. newjobsurveyadmin",
+    "RoleName": "The role name for an New Job Survey Admin use, e.g. newjobsurveyadmin",
+    "RoleClaimType": "The claim that contains the user role, e.g. user_roles",
     "Audience": "The audience that provided service tokens must have, e.g. CallWebApi"
   },
   "Email": {
     "FromName": "The name to be shown on emails sent, e.g. Do Not Reply",
     "FromAddress": "The reply address to be shown on emails sent, e.g. noreply@someserver",
-    "ToName": "The name to send emails to, e.g. Admin Team",
-    "ToAddress": "The address to send emails to, e.g. adminteam@someserver",
+    "ToName": "The name to send emails to, e.g. Admin Team",    "ToAddress": "The address to send emails to, e.g. adminteam@someserver",
     "SmtpServer": "The SMTP server, e.g. some.smtp.server",
     "SmtpPort": 25
   },

--- a/secret/appsettings.secret-template.json
+++ b/secret/appsettings.secret-template.json
@@ -11,7 +11,8 @@
   "Email": {
     "FromName": "The name to be shown on emails sent, e.g. Do Not Reply",
     "FromAddress": "The reply address to be shown on emails sent, e.g. noreply@someserver",
-    "ToName": "The name to send emails to, e.g. Admin Team",    "ToAddress": "The address to send emails to, e.g. adminteam@someserver",
+    "ToName": "The name to send emails to, e.g. Admin Team",
+    "ToAddress": "The address to send emails to, e.g. adminteam@someserver",
     "SmtpServer": "The SMTP server, e.g. some.smtp.server",
     "SmtpPort": 25
   },


### PR DESCRIPTION
Fixes #107.

The issue is that the correct role was not being verified by the `[Authorize]` annotation. I switched to use a [policy-based approach](https://learn.microsoft.com/en-us/aspnet/core/security/authorization/claims?view=aspnetcore-3.1), which verifies that the correct role exists on the user.

**NB: requires an additional appsettings.json setting; see below.**

This PR also corrects another issue, which is that the claim containing the roles (e.g. `user_roles`) on the JWT was hardcoded and could not be specified in the settings file, e.g. in case it changes in the future.

The `RoleClaimType` setting is now required in the `Authentication` part of the `appsettings.json` secret. See the additional line in the `appsettings.secret-template.json` file.

